### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ fivecentplots/__pycache__/fcp.cpython-35.pyc
 
 #pytest
 .pytest_cache
+/meta.yaml

--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@ Custom plotting wrapper for matplotlib
 pip install https://github.com/endangeredoxen/fivecentplots/zipball/master
 
 Read the docs:  https://endangeredoxen.github.io/fivecentplots/
+
+### Changelog
+
+**0.3.1** 2019/08/06
+- Conda packaging
+- Handle getattr != None bug

--- a/conda_release.py
+++ b/conda_release.py
@@ -1,0 +1,51 @@
+import fivecentplots
+import os
+
+# Move to this directory (to check git repo)
+build_dir = os.path.dirname(os.path.abspath(__file__))
+os.chdir(build_dir)
+
+meta_text = f"""
+package:
+  name: fivecentplots
+  version: {fivecentplots.__version__}
+
+source:
+  path: {build_dir}
+
+build:
+  noarch: python
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  host:
+    - python
+    - setuptools
+  run:
+    - python
+    - bokeh >=1.3.1
+    - matplotlib >=3.1.0
+    - pandas >=0.25.0
+    - pywin32 >=223
+    - scipy >=1.3.0
+    - xlrd >=1.2.0
+
+test:
+  imports:
+    - fivecentplots
+
+about:
+  home: https://github.com/endangeredoxen/fivecentplots
+  license: GPLv3
+  summary: "Custom plotting wrapper for matplotlib"
+  description: |
+    Custom plotting wrapper for matplotlib
+  dev_url: https://github.com/endangeredoxen/fivecentplots
+  doc_url: https://github.com/endangeredoxen/fivecentplots
+  doc_source_url: https://github.com/endangeredoxen/fivecentplots/blob/master/README.rst
+"""
+
+with open("meta.yaml", "w") as fp:
+    fp.write(meta_text)
+
+os.system(f"conda build {build_dir}")

--- a/fivecentplots/data.py
+++ b/fivecentplots/data.py
@@ -589,7 +589,7 @@ class Data:
             min, max tuple
         """
 
-        if not hasattr(self, ax) or getattr(self, ax) is None:
+        if not hasattr(self, ax) or getattr(self, ax) in [None, []]:
             return None, None
         elif self.col == 'x' and self.share_x and ax == 'x':
             cols = self.x_vals

--- a/fivecentplots/fcp.py
+++ b/fivecentplots/fcp.py
@@ -10,7 +10,7 @@
 __author__    = 'Steve Nicholes'
 __copyright__ = 'Copyright (C) 2016 Steve Nicholes'
 __license__   = 'GPLv3'
-__version__   = '0.3.0'
+__version__   = '0.3.1'
 __url__       = 'https://github.com/endangeredoxen/fivecentplots'
 import os
 import numpy as np

--- a/setup.py
+++ b/setup.py
@@ -64,12 +64,12 @@ setup(
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=['contrib', 'docs', 'tests*', ]),
 
-    dependency_links = ['https://github.com/endangeredoxen/fileio/zipball/master'],
+    dependency_links=['https://github.com/endangeredoxen/fileio/zipball/master'],
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['pandas', 'numpy', 'matplotlib'], #'fileio==0.2.2'],
+    install_requires=['pandas', 'numpy', 'matplotlib'],  # 'fileio==0.2.2'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
@@ -83,7 +83,7 @@ setup(
     # installed, specify them here.  If using Python 2.6 or less, then these
     # have to be included in MANIFEST.in as well.
     package_data={
-        'fivecentplots': ['themes/gray.py','themes/white.py', 'tests/*', 'doc/_static/docstrings/*', 'keywords.xlsx'],
+        'fivecentplots': ['themes/gray.py', 'themes/white.py', 'tests/*', 'doc/_static/docstrings/*', 'keywords.xlsx'],
     },
 
     # Although 'package_data' is the preferred approach, in some case you may


### PR DESCRIPTION
Added conda recipe (assumed "conda build" is available on command line). I've never released a package publicly to 

Added a changelog by version number to the README. We've found that to be pretty handy when comparing version diffs at a glance.

I ran into some errors getting the data range when using getattr(self, ax) for unused axes. Commit d2824 has details on that one. I think it's likely a getattr behavior change between python 3.5 and 3.7 (we're using 3.7, but your .idea file references 3.5).

Setup.py only contains cosmetic formatting changes.

If you like the changes, I figured it was appropriate to increment the version number.