### PR TITLE
fix: guard against IndexError in set_figure_final_layout for sparse subplot grids

### DIFF
--- a/src/fivecentplots/engines/mpl.py
+++ b/src/fivecentplots/engines/mpl.py
@@ -4493,7 +4493,10 @@ class Layout(BaseLayout):
                         if idiv >= len(changes.index):
                             continue
                         div_at = changes.index[idiv]
-                        loc = lab_bg_size.loc[ir, ic, idx].iloc[div_at - 1].x1
+                        _slice = lab_bg_size.loc[ir, ic, idx]
+                        if div_at - 1 >= len(_slice):
+                            continue
+                        loc = _slice.iloc[div_at - 1].x1
                         div.set_xdata([loc / self.fig.size_int[0], loc / self.fig.size_int[0]])
 
                 # group title


### PR DESCRIPTION
## Summary

Fixes `IndexError: single positional indexer is out-of-bounds` in `set_figure_final_layout` when `fcp.boxplot` is called with 3+ group columns that produce a sparse subplot grid (some row×col cells have no data).

## Root Cause

In `engines/mpl.py`, the divider-placement loop computes `div_at - 1` as an index into `lab_bg_size.loc[ir, ic, idx]`. For sparse grids, the label-background array has fewer entries than the number of dividers, causing `iloc[div_at - 1]` to exceed the slice length.

## Fix

Guard with a bounds check before indexing — if the slice is too short for the computed index, skip that divider cell.

```python
# Before
loc = lab_bg_size.loc[ir, ic, idx].iloc[div_at - 1].x1

# After
_slice = lab_bg_size.loc[ir, ic, idx]
if div_at - 1 >= len(_slice):
    continue
loc = _slice.iloc[div_at - 1].x1
```

## Reproduction

The reproducer from #81 crashes before this fix and renders correctly after.

Closes #81
